### PR TITLE
BACK-031/032/033/060 - GitHub integration and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,185 @@
+# PortLoko
+
+PortLoko is a developer portfolio platform focused on live, deployable projects. The current repository contains the Quarkus Core API and the CI workflow used to validate it.
+
+## Current Stack
+
+- Java 21
+- Quarkus 3.x
+- Maven
+- Hibernate ORM with Panache
+- PostgreSQL in local/dev environments
+- H2 for tests
+- Flyway migrations
+- SmallRye JWT
+- GitHub Actions
+
+## Repository Layout
+
+```text
+Portfolio/
+├── core-api/                 # Quarkus Core API
+│   ├── src/main/java/com/portloko/
+│   │   ├── github/           # GitHub API client
+│   │   ├── project/          # Project model/repository
+│   │   ├── shared/           # Shared exceptions and error mappers
+│   │   └── user/             # User profile API
+│   └── src/main/resources/
+│       ├── application.properties
+│       └── db/migration/     # Flyway migrations
+├── .github/workflows/        # CI workflows
+├── install_start.ps1         # Windows setup/test/build/start helper
+└── install_start.sh          # Unix/Git Bash setup/test/build/start helper
+```
+
+Planned services include a runner service for isolated project builds and deployment orchestration.
+
+## Prerequisites
+
+- Java 21 available in `PATH`
+- Maven available in `PATH`
+- Git
+- GitHub CLI (`gh`) for PR/check commands
+- PostgreSQL for running the API locally against a real database
+
+The tests do not require PostgreSQL because the test profile uses H2.
+
+## Configuration
+
+The Core API reads configuration from environment variables with local defaults in `core-api/src/main/resources/application.properties`.
+
+Useful variables:
+
+```text
+DATABASE_URL=jdbc:postgresql://localhost:5432/portloko
+DB_USER=portloko
+DB_PASSWORD=portloko
+JWT_PUBLIC_KEY_LOCATION=keys/public.pem
+JWT_ISSUER=https://portloko.dev
+CORS_ORIGINS=http://localhost:3000
+GITHUB_API_BASE_URL=https://api.github.com
+GITHUB_ARCHIVE_TEMP_DIR=
+GITHUB_ARCHIVE_MAX_BYTES=52428800
+```
+
+For tests, no local `.env` is required.
+
+## Validate The Project
+
+From the repository root:
+
+```powershell
+cd core-api
+mvn -B -ntp test
+mvn -B -ntp verify
+```
+
+`mvn verify` matches the GitHub Actions validation workflow.
+
+On Windows, you can also use:
+
+```powershell
+.\install_start.ps1 -NoStart
+```
+
+On Git Bash, WSL, Linux, or macOS:
+
+```bash
+NO_START=true ./install_start.sh
+```
+
+The `NoStart` / `NO_START=true` mode runs tests and builds the application without starting Quarkus dev mode.
+
+## Start The Core API
+
+Make sure PostgreSQL is available, then run one of:
+
+```powershell
+.\install_start.ps1
+```
+
+```bash
+./install_start.sh
+```
+
+Or start Quarkus directly:
+
+```powershell
+cd core-api
+mvn quarkus:dev
+```
+
+The API runs on:
+
+```text
+http://localhost:8080
+```
+
+Swagger UI is included by Quarkus when the application starts.
+
+## GitHub Integration
+
+The `com.portloko.github` package contains the GitHub API client used by deployment flows.
+
+Implemented capabilities:
+
+- List authenticated user repositories through `GET /user/repos`
+- Filter repositories by `permissions.push`
+- Paginate GitHub results with `per_page=100`
+- Resolve a branch or tag to a full 40-character commit SHA
+- Download a repository tarball for a specific commit SHA
+- Store archives in a temporary directory
+- Clean up downloaded archives after use
+- Reject archives larger than `GITHUB_ARCHIVE_MAX_BYTES`
+
+External GitHub calls are covered by unit tests using a local HTTP server, not the real GitHub API.
+
+## Code Conventions
+
+- Packages live under `com.portloko.{module}`
+- REST resources end with `Resource`
+- Services end with `Service`
+- Repositories use Panache repositories
+- DTOs are Java records
+- Error responses use `{ "error": "...", "code": "..." }`
+- Tests live in the same package under `src/test/java`
+- Use `@QuarkusTest` for API/integration tests and JUnit + Mockito or local fakes for unit tests
+- Do not commit secrets or local `.env` files
+
+## Pull Request Workflow
+
+1. Create a feature branch:
+
+   ```bash
+   git switch -c feature/BACK-123-short-description
+   ```
+
+2. Implement the change with focused tests.
+
+3. Validate locally:
+
+   ```bash
+   cd core-api
+   mvn -B -ntp verify
+   ```
+
+4. Push and open a PR:
+
+   ```bash
+   git push -u origin feature/BACK-123-short-description
+   gh pr create --base main --head feature/BACK-123-short-description
+   ```
+
+5. Wait for the GitHub Actions check `Validate Quarkus Core API` to pass before merging.
+
+## Useful Commands
+
+```powershell
+git status --short
+gh pr checks <pr-number> --repo potichacha/Portfolio
+gh pr view <pr-number> --repo potichacha/Portfolio
+```
+
+## Notes
+
+The local scripts use the installed `mvn` command. If the Maven wrapper jar is missing or invalid locally, use `mvn` directly.

--- a/core-api/src/main/java/com/portloko/github/GitHubApiException.java
+++ b/core-api/src/main/java/com/portloko/github/GitHubApiException.java
@@ -1,0 +1,21 @@
+package com.portloko.github;
+
+public class GitHubApiException extends RuntimeException {
+
+    private final int statusCode;
+    private final String code;
+
+    public GitHubApiException(String message, int statusCode, String code) {
+        super(message);
+        this.statusCode = statusCode;
+        this.code = code;
+    }
+
+    public int statusCode() {
+        return statusCode;
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/core-api/src/main/java/com/portloko/github/GitHubArchive.java
+++ b/core-api/src/main/java/com/portloko/github/GitHubArchive.java
@@ -1,0 +1,11 @@
+package com.portloko.github;
+
+import java.nio.file.Path;
+
+public record GitHubArchive(
+        Path path,
+        String owner,
+        String repository,
+        String sha,
+        long sizeBytes
+) {}

--- a/core-api/src/main/java/com/portloko/github/GitHubClient.java
+++ b/core-api/src/main/java/com/portloko/github/GitHubClient.java
@@ -1,0 +1,367 @@
+package com.portloko.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@ApplicationScoped
+public class GitHubClient {
+
+    private static final int REPOSITORIES_PER_PAGE = 100;
+    private static final TypeReference<List<RepositoryPayload>> REPOSITORY_LIST_TYPE = new TypeReference<>() {};
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @ConfigProperty(name = "github.api.base-url", defaultValue = "https://api.github.com")
+    String apiBaseUrl;
+
+    @ConfigProperty(name = "github.archive.temp-dir", defaultValue = "")
+    Optional<String> archiveTempDir;
+
+    @ConfigProperty(name = "github.archive.max-bytes", defaultValue = "52428800")
+    long maxArchiveBytes;
+
+    private HttpClient httpClient;
+    private Path archiveDirectory;
+
+    public GitHubClient() {
+        this(HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    GitHubClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    GitHubClient(HttpClient httpClient, ObjectMapper objectMapper, String apiBaseUrl, Path archiveDirectory, long maxArchiveBytes) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.apiBaseUrl = normalizeBaseUrl(apiBaseUrl);
+        this.archiveDirectory = archiveDirectory;
+        this.maxArchiveBytes = maxArchiveBytes;
+    }
+
+    @PostConstruct
+    void init() {
+        apiBaseUrl = normalizeBaseUrl(apiBaseUrl);
+        archiveDirectory = archiveTempDir
+                .filter(value -> !value.isBlank())
+                .map(Path::of)
+                .orElseGet(() -> Path.of(System.getProperty("java.io.tmpdir"), "portloko-github-archives"));
+    }
+
+    public List<GitHubRepositoryResponse> listRepositories(String oauthToken) {
+        validateToken(oauthToken);
+
+        List<GitHubRepositoryResponse> repositories = new ArrayList<>();
+        int page = 1;
+        boolean hasNextPage;
+
+        do {
+            HttpResponse<String> response = sendJson(request("/user/repos?per_page=" + REPOSITORIES_PER_PAGE + "&page=" + page, oauthToken)
+                    .GET()
+                    .build());
+            ensureSuccess(response, "Unable to list GitHub repositories");
+
+            List<RepositoryPayload> payloads = readRepositoryPayloads(response.body());
+            payloads.stream()
+                    .filter(RepositoryPayload::canPush)
+                    .map(RepositoryPayload::toResponse)
+                    .forEach(repositories::add);
+
+            hasNextPage = hasNextPage(response) || payloads.size() == REPOSITORIES_PER_PAGE;
+            page++;
+        } while (hasNextPage);
+
+        return repositories;
+    }
+
+    public String resolveCommitSha(String oauthToken, String owner, String repository, String ref) {
+        validateToken(oauthToken);
+        validateOwnerRepositoryAndRef(owner, repository, ref);
+
+        GitReference reference = getReference(oauthToken, owner, repository, "heads", ref);
+        if (reference == null) {
+            reference = getReference(oauthToken, owner, repository, "tags", ref);
+        }
+        if (reference == null) {
+            throw new GitHubApiException("GitHub branch or tag not found", 404, "GITHUB_REF_NOT_FOUND");
+        }
+
+        if ("tag".equals(reference.object().type())) {
+            GitTag tag = getTag(oauthToken, owner, repository, reference.object().sha());
+            return validateCommitSha(tag.object().sha());
+        }
+
+        return validateCommitSha(reference.object().sha());
+    }
+
+    public GitHubArchive downloadTarball(String oauthToken, String owner, String repository, String sha) {
+        validateToken(oauthToken);
+        validateOwnerRepositoryAndRef(owner, repository, sha);
+        validateCommitSha(sha);
+
+        try {
+            Files.createDirectories(archiveDirectory);
+            String prefix = safeFilePart(owner) + "-" + safeFilePart(repository) + "-" + sha.substring(0, 12) + "-";
+            Path archivePath = Files.createTempFile(archiveDirectory, prefix, ".tar.gz");
+            long sizeBytes = downloadTarballTo(oauthToken, owner, repository, sha, archivePath);
+            return new GitHubArchive(archivePath, owner, repository, sha, sizeBytes);
+        } catch (GitHubApiException exception) {
+            throw exception;
+        } catch (IOException exception) {
+            throw new GitHubApiException("Unable to store GitHub archive", 500, "GITHUB_ARCHIVE_STORAGE_ERROR");
+        }
+    }
+
+    public void cleanupArchive(GitHubArchive archive) {
+        if (archive == null || archive.path() == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(archive.path());
+        } catch (IOException exception) {
+            throw new GitHubApiException("Unable to clean GitHub archive", 500, "GITHUB_ARCHIVE_CLEANUP_ERROR");
+        }
+    }
+
+    private long downloadTarballTo(String oauthToken, String owner, String repository, String sha, Path archivePath) throws IOException {
+        HttpRequest request = request("/repos/" + encodePathSegment(owner)
+                + "/" + encodePathSegment(repository)
+                + "/tarball/" + encodePathSegment(sha), oauthToken)
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                closeQuietly(response.body());
+                Files.deleteIfExists(archivePath);
+                throw mapError(response.statusCode(), "Unable to download GitHub archive");
+            }
+
+            long totalBytes = copyArchive(response.body(), archivePath);
+            if (totalBytes > maxArchiveBytes) {
+                Files.deleteIfExists(archivePath);
+                throw new GitHubApiException("GitHub archive is too large", 413, "GITHUB_ARCHIVE_TOO_LARGE");
+            }
+            return totalBytes;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            Files.deleteIfExists(archivePath);
+            throw new GitHubApiException("GitHub archive download interrupted", 500, "GITHUB_ARCHIVE_DOWNLOAD_INTERRUPTED");
+        } catch (GitHubApiException exception) {
+            Files.deleteIfExists(archivePath);
+            throw exception;
+        }
+    }
+
+    private long copyArchive(InputStream responseBody, Path archivePath) throws IOException {
+        try (InputStream input = responseBody;
+             var output = Files.newOutputStream(archivePath)) {
+            byte[] buffer = new byte[8192];
+            long totalBytes = 0;
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                totalBytes += read;
+                if (totalBytes <= maxArchiveBytes) {
+                    output.write(buffer, 0, read);
+                }
+            }
+            return totalBytes;
+        }
+    }
+
+    private GitReference getReference(String oauthToken, String owner, String repository, String namespace, String ref) {
+        HttpResponse<String> response = sendJson(request("/repos/" + encodePathSegment(owner)
+                + "/" + encodePathSegment(repository)
+                + "/git/ref/" + namespace + "/" + encodeGitRef(ref), oauthToken)
+                .GET()
+                .build());
+
+        if (response.statusCode() == 404) {
+            return null;
+        }
+        ensureSuccess(response, "Unable to resolve GitHub ref");
+        return readValue(response.body(), GitReference.class);
+    }
+
+    private GitTag getTag(String oauthToken, String owner, String repository, String tagSha) {
+        HttpResponse<String> response = sendJson(request("/repos/" + encodePathSegment(owner)
+                + "/" + encodePathSegment(repository)
+                + "/git/tags/" + encodePathSegment(tagSha), oauthToken)
+                .GET()
+                .build());
+        ensureSuccess(response, "Unable to resolve GitHub tag");
+        return readValue(response.body(), GitTag.class);
+    }
+
+    private HttpRequest.Builder request(String pathAndQuery, String oauthToken) {
+        return HttpRequest.newBuilder(URI.create(apiBaseUrl + pathAndQuery))
+                .timeout(Duration.ofSeconds(30))
+                .header("Accept", "application/vnd.github+json")
+                .header("Authorization", "Bearer " + oauthToken)
+                .header("User-Agent", "PortLoko-Core-API")
+                .header("X-GitHub-Api-Version", "2022-11-28");
+    }
+
+    private HttpResponse<String> sendJson(HttpRequest request) {
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        } catch (IOException exception) {
+            throw new GitHubApiException("Unable to reach GitHub API", 502, "GITHUB_API_UNAVAILABLE");
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new GitHubApiException("GitHub API request interrupted", 500, "GITHUB_API_INTERRUPTED");
+        }
+    }
+
+    private List<RepositoryPayload> readRepositoryPayloads(String body) {
+        try {
+            return objectMapper.readValue(body, REPOSITORY_LIST_TYPE);
+        } catch (IOException exception) {
+            throw new GitHubApiException("Unable to parse GitHub repositories response", 502, "GITHUB_API_INVALID_RESPONSE");
+        }
+    }
+
+    private <T> T readValue(String body, Class<T> type) {
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (IOException exception) {
+            throw new GitHubApiException("Unable to parse GitHub response", 502, "GITHUB_API_INVALID_RESPONSE");
+        }
+    }
+
+    private void ensureSuccess(HttpResponse<?> response, String message) {
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw mapError(response.statusCode(), message);
+        }
+    }
+
+    private GitHubApiException mapError(int statusCode, String message) {
+        return switch (statusCode) {
+            case 401 -> new GitHubApiException("GitHub token is invalid or expired", 401, "GITHUB_UNAUTHORIZED");
+            case 403 -> new GitHubApiException("GitHub repository is inaccessible or the token lacks scope", 403, "GITHUB_FORBIDDEN");
+            case 404 -> new GitHubApiException("GitHub resource not found", 404, "GITHUB_NOT_FOUND");
+            case 413 -> new GitHubApiException("GitHub archive is too large", 413, "GITHUB_ARCHIVE_TOO_LARGE");
+            default -> new GitHubApiException(message, statusCode, "GITHUB_API_ERROR");
+        };
+    }
+
+    private boolean hasNextPage(HttpResponse<?> response) {
+        return response.headers()
+                .firstValue("Link")
+                .map(link -> link.contains("rel=\"next\""))
+                .orElse(false);
+    }
+
+    private String validateCommitSha(String sha) {
+        if (sha == null || sha.length() != 40 || !sha.chars().allMatch(this::isHexDigit)) {
+            throw new GitHubApiException("GitHub commit SHA is invalid", 502, "GITHUB_INVALID_SHA");
+        }
+        return sha.toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isHexDigit(int character) {
+        return (character >= '0' && character <= '9')
+                || (character >= 'a' && character <= 'f')
+                || (character >= 'A' && character <= 'F');
+    }
+
+    private void validateToken(String oauthToken) {
+        if (oauthToken == null || oauthToken.isBlank()) {
+            throw new GitHubApiException("GitHub OAuth token is required", 401, "GITHUB_TOKEN_REQUIRED");
+        }
+    }
+
+    private void validateOwnerRepositoryAndRef(String owner, String repository, String ref) {
+        if (owner == null || owner.isBlank() || repository == null || repository.isBlank() || ref == null || ref.isBlank()) {
+            throw new GitHubApiException("GitHub owner, repository and reference are required", 400, "GITHUB_INVALID_REQUEST");
+        }
+    }
+
+    private String encodePathSegment(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private String encodeGitRef(String value) {
+        return List.of(value.split("/", -1)).stream()
+                .map(this::encodePathSegment)
+                .reduce((left, right) -> left + "/" + right)
+                .orElse("");
+    }
+
+    private String safeFilePart(String value) {
+        return value.replaceAll("[^a-zA-Z0-9._-]", "-");
+    }
+
+    private static String normalizeBaseUrl(String baseUrl) {
+        if (baseUrl.endsWith("/")) {
+            return baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl;
+    }
+
+    private void closeQuietly(InputStream inputStream) {
+        try {
+            inputStream.close();
+        } catch (IOException ignored) {
+            // Best effort cleanup for error responses.
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record RepositoryPayload(
+            String name,
+            @JsonProperty("full_name") String fullName,
+            @JsonProperty("html_url") String htmlUrl,
+            String language,
+            String description,
+            @JsonProperty("default_branch") String defaultBranch,
+            RepositoryPermissions permissions
+    ) {
+        boolean canPush() {
+            return permissions != null && permissions.push();
+        }
+
+        GitHubRepositoryResponse toResponse() {
+            return new GitHubRepositoryResponse(name, fullName, htmlUrl, language, description, defaultBranch);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record RepositoryPermissions(boolean push) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record GitReference(GitObject object) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record GitTag(GitObject object) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record GitObject(String sha, String type) {}
+}

--- a/core-api/src/main/java/com/portloko/github/GitHubRepositoryResponse.java
+++ b/core-api/src/main/java/com/portloko/github/GitHubRepositoryResponse.java
@@ -1,0 +1,12 @@
+package com.portloko.github;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GitHubRepositoryResponse(
+        String name,
+        @JsonProperty("full_name") String fullName,
+        @JsonProperty("html_url") String htmlUrl,
+        String language,
+        String description,
+        @JsonProperty("default_branch") String defaultBranch
+) {}

--- a/core-api/src/main/resources/application.properties
+++ b/core-api/src/main/resources/application.properties
@@ -39,6 +39,11 @@ quarkus.smallrye-openapi.info-version=1.0.0
 quarkus.smallrye-openapi.info-description=Backend API for PortLoko developer portfolio platform
 quarkus.swagger-ui.always-include=true
 
+# --- GitHub API ---
+github.api.base-url=${GITHUB_API_BASE_URL:https://api.github.com}
+github.archive.temp-dir=${GITHUB_ARCHIVE_TEMP_DIR:}
+github.archive.max-bytes=${GITHUB_ARCHIVE_MAX_BYTES:52428800}
+
 # --- Logging ---
 quarkus.log.level=INFO
 quarkus.log.category."com.portloko".level=DEBUG

--- a/core-api/src/test/java/com/portloko/github/GitHubClientTest.java
+++ b/core-api/src/test/java/com/portloko/github/GitHubClientTest.java
@@ -1,0 +1,329 @@
+package com.portloko.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GitHubClientTest {
+
+    private static final String TOKEN = "gho_test-token";
+
+    private final Map<String, Queue<StubResponse>> stubs = new ConcurrentHashMap<>();
+    private final List<RecordedRequest> requests = new CopyOnWriteArrayList<>();
+
+    private HttpServer server;
+    private GitHubClient client;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", this::handleRequest);
+        server.start();
+        client = newClient(1024);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void listRepositories_paginatesWithOneHundredPerPageAndFiltersPushPermission() {
+        stubJson(
+                "/user/repos?per_page=100&page=1",
+                200,
+                Map.of("Link", List.of("<" + baseUrl() + "/user/repos?per_page=100&page=2>; rel=\"next\"")),
+                """
+                        [
+                          {
+                            "name": "deployable",
+                            "full_name": "octo/deployable",
+                            "html_url": "https://github.com/octo/deployable",
+                            "language": "Java",
+                            "description": "Ready to ship",
+                            "default_branch": "main",
+                            "permissions": { "push": true }
+                          },
+                          {
+                            "name": "readonly",
+                            "full_name": "octo/readonly",
+                            "html_url": "https://github.com/octo/readonly",
+                            "language": "TypeScript",
+                            "description": "Read only",
+                            "default_branch": "main",
+                            "permissions": { "push": false }
+                          }
+                        ]
+                        """
+        );
+        stubJson(
+                "/user/repos?per_page=100&page=2",
+                200,
+                """
+                        [
+                          {
+                            "name": "portfolio",
+                            "full_name": "octo/portfolio",
+                            "html_url": "https://github.com/octo/portfolio",
+                            "language": "Vue",
+                            "description": null,
+                            "default_branch": "develop",
+                            "permissions": { "push": true }
+                          }
+                        ]
+                        """
+        );
+
+        List<GitHubRepositoryResponse> repositories = client.listRepositories(TOKEN);
+
+        assertThat(repositories).hasSize(2);
+        assertThat(repositories).extracting(GitHubRepositoryResponse::name)
+                .containsExactly("deployable", "portfolio");
+        assertThat(repositories.getFirst().fullName()).isEqualTo("octo/deployable");
+        assertThat(repositories.getFirst().htmlUrl()).isEqualTo("https://github.com/octo/deployable");
+        assertThat(repositories.getFirst().language()).isEqualTo("Java");
+        assertThat(repositories.getFirst().description()).isEqualTo("Ready to ship");
+        assertThat(repositories.getFirst().defaultBranch()).isEqualTo("main");
+        assertThat(requests).extracting(RecordedRequest::pathAndQuery)
+                .containsExactly("/user/repos?per_page=100&page=1", "/user/repos?per_page=100&page=2");
+        assertThat(requests).allSatisfy(request -> assertThat(request.authorization()).isEqualTo("Bearer " + TOKEN));
+    }
+
+    @Test
+    void resolveCommitSha_usesHeadsRefAndReturnsFullSha() {
+        String sha = "a".repeat(40);
+        stubJson(
+                "/repos/octo/demo/git/ref/heads/feature/deploy",
+                200,
+                """
+                        {
+                          "object": {
+                            "type": "commit",
+                            "sha": "%s"
+                          }
+                        }
+                        """.formatted(sha)
+        );
+
+        String resolvedSha = client.resolveCommitSha(TOKEN, "octo", "demo", "feature/deploy");
+
+        assertThat(resolvedSha).isEqualTo(sha);
+        assertThat(requests).extracting(RecordedRequest::pathAndQuery)
+                .containsExactly("/repos/octo/demo/git/ref/heads/feature/deploy");
+    }
+
+    @Test
+    void resolveCommitSha_fallsBackToTagAndDereferencesAnnotatedTag() {
+        String tagSha = "b".repeat(40);
+        String commitSha = "c".repeat(40);
+        stubJson("/repos/octo/demo/git/ref/heads/v1.0.0", 404, "{}");
+        stubJson(
+                "/repos/octo/demo/git/ref/tags/v1.0.0",
+                200,
+                """
+                        {
+                          "object": {
+                            "type": "tag",
+                            "sha": "%s"
+                          }
+                        }
+                        """.formatted(tagSha)
+        );
+        stubJson(
+                "/repos/octo/demo/git/tags/%s".formatted(tagSha),
+                200,
+                """
+                        {
+                          "object": {
+                            "type": "commit",
+                            "sha": "%s"
+                          }
+                        }
+                        """.formatted(commitSha)
+        );
+
+        String resolvedSha = client.resolveCommitSha(TOKEN, "octo", "demo", "v1.0.0");
+
+        assertThat(resolvedSha).isEqualTo(commitSha);
+        assertThat(requests).extracting(RecordedRequest::pathAndQuery)
+                .containsExactly(
+                        "/repos/octo/demo/git/ref/heads/v1.0.0",
+                        "/repos/octo/demo/git/ref/tags/v1.0.0",
+                        "/repos/octo/demo/git/tags/%s".formatted(tagSha)
+                );
+    }
+
+    @Test
+    void resolveCommitSha_throwsNotFoundWhenBranchAndTagAreMissing() {
+        stubJson("/repos/octo/demo/git/ref/heads/missing", 404, "{}");
+        stubJson("/repos/octo/demo/git/ref/tags/missing", 404, "{}");
+
+        assertThatThrownBy(() -> client.resolveCommitSha(TOKEN, "octo", "demo", "missing"))
+                .isInstanceOf(GitHubApiException.class)
+                .satisfies(exception -> {
+                    GitHubApiException githubException = (GitHubApiException) exception;
+                    assertThat(githubException.statusCode()).isEqualTo(404);
+                    assertThat(githubException.code()).isEqualTo("GITHUB_REF_NOT_FOUND");
+                });
+    }
+
+    @Test
+    void resolveCommitSha_throwsForbiddenWhenRepositoryIsInaccessible() {
+        stubJson("/repos/octo/private/git/ref/heads/main", 403, "{}");
+
+        assertThatThrownBy(() -> client.resolveCommitSha(TOKEN, "octo", "private", "main"))
+                .isInstanceOf(GitHubApiException.class)
+                .satisfies(exception -> {
+                    GitHubApiException githubException = (GitHubApiException) exception;
+                    assertThat(githubException.statusCode()).isEqualTo(403);
+                    assertThat(githubException.code()).isEqualTo("GITHUB_FORBIDDEN");
+                });
+        assertThat(requests).extracting(RecordedRequest::pathAndQuery)
+                .containsExactly("/repos/octo/private/git/ref/heads/main");
+    }
+
+    @Test
+    void downloadTarball_storesArchiveAndCleanupDeletesIt() throws IOException {
+        String sha = "d".repeat(40);
+        byte[] archiveBytes = "tarball-content".getBytes(StandardCharsets.UTF_8);
+        stubBinary("/repos/octo/demo/tarball/" + sha, 200, archiveBytes);
+
+        GitHubArchive archive = client.downloadTarball(TOKEN, "octo", "demo", sha);
+
+        assertThat(archive.owner()).isEqualTo("octo");
+        assertThat(archive.repository()).isEqualTo("demo");
+        assertThat(archive.sha()).isEqualTo(sha);
+        assertThat(archive.sizeBytes()).isEqualTo(archiveBytes.length);
+        assertThat(archive.path()).exists();
+        assertThat(Files.readAllBytes(archive.path())).isEqualTo(archiveBytes);
+
+        client.cleanupArchive(archive);
+
+        assertThat(archive.path()).doesNotExist();
+    }
+
+    @Test
+    void downloadTarball_deletesPartialFileWhenArchiveIsTooLarge() throws IOException {
+        String sha = "e".repeat(40);
+        client = newClient(4);
+        stubBinary("/repos/octo/demo/tarball/" + sha, 200, "12345".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> client.downloadTarball(TOKEN, "octo", "demo", sha))
+                .isInstanceOf(GitHubApiException.class)
+                .satisfies(exception -> {
+                    GitHubApiException githubException = (GitHubApiException) exception;
+                    assertThat(githubException.statusCode()).isEqualTo(413);
+                    assertThat(githubException.code()).isEqualTo("GITHUB_ARCHIVE_TOO_LARGE");
+                });
+        try (var paths = Files.list(tempDir)) {
+            assertThat(paths.toList()).isEmpty();
+        }
+    }
+
+    @Test
+    void downloadTarball_throwsForbiddenForPrivateRepositoryWithoutScope() throws IOException {
+        String sha = "f".repeat(40);
+        stubJson("/repos/octo/private/tarball/" + sha, 403, "{}");
+
+        assertThatThrownBy(() -> client.downloadTarball(TOKEN, "octo", "private", sha))
+                .isInstanceOf(GitHubApiException.class)
+                .satisfies(exception -> {
+                    GitHubApiException githubException = (GitHubApiException) exception;
+                    assertThat(githubException.statusCode()).isEqualTo(403);
+                    assertThat(githubException.code()).isEqualTo("GITHUB_FORBIDDEN");
+                });
+        try (var paths = Files.list(tempDir)) {
+            assertThat(paths.toList()).isEmpty();
+        }
+    }
+
+    private GitHubClient newClient(long maxArchiveBytes) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(2))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+        return new GitHubClient(httpClient, new ObjectMapper(), baseUrl(), tempDir, maxArchiveBytes);
+    }
+
+    private String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    private void stubJson(String pathAndQuery, int statusCode, String body) {
+        stubJson(pathAndQuery, statusCode, Map.of(), body);
+    }
+
+    private void stubJson(String pathAndQuery, int statusCode, Map<String, List<String>> headers, String body) {
+        stub(pathAndQuery, statusCode, withContentType(headers, "application/json"), body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void stubBinary(String pathAndQuery, int statusCode, byte[] body) {
+        stub(pathAndQuery, statusCode, Map.of("Content-Type", List.of("application/octet-stream")), body);
+    }
+
+    private void stub(String pathAndQuery, int statusCode, Map<String, List<String>> headers, byte[] body) {
+        stubs.computeIfAbsent(pathAndQuery, ignored -> new ArrayDeque<>())
+                .add(new StubResponse(statusCode, headers, body));
+    }
+
+    private Map<String, List<String>> withContentType(Map<String, List<String>> headers, String contentType) {
+        if (headers.containsKey("Content-Type")) {
+            return headers;
+        }
+        Map<String, List<String>> merged = new ConcurrentHashMap<>(headers);
+        merged.put("Content-Type", List.of(contentType));
+        return merged;
+    }
+
+    private void handleRequest(HttpExchange exchange) throws IOException {
+        String pathAndQuery = exchange.getRequestURI().getRawPath();
+        if (exchange.getRequestURI().getRawQuery() != null) {
+            pathAndQuery += "?" + exchange.getRequestURI().getRawQuery();
+        }
+        requests.add(new RecordedRequest(
+                exchange.getRequestMethod(),
+                pathAndQuery,
+                exchange.getRequestHeaders().getFirst("Authorization")
+        ));
+
+        StubResponse response = stubs.getOrDefault(pathAndQuery, new ArrayDeque<>()).poll();
+        if (response == null) {
+            response = new StubResponse(500, Map.of("Content-Type", List.of("text/plain")), ("No stub for " + pathAndQuery).getBytes(StandardCharsets.UTF_8));
+        }
+
+        response.headers().forEach((name, values) -> values.forEach(value -> exchange.getResponseHeaders().add(name, value)));
+        exchange.sendResponseHeaders(response.statusCode(), response.body().length);
+        try (OutputStream responseBody = exchange.getResponseBody()) {
+            responseBody.write(response.body());
+        }
+    }
+
+    record StubResponse(int statusCode, Map<String, List<String>> headers, byte[] body) {}
+
+    record RecordedRequest(String method, String pathAndQuery, String authorization) {}
+}


### PR DESCRIPTION
Closes #130

## Summary
- Add GitHubClient for OAuth-backed repository listing with push-permission filtering and 100/page pagination.
- Resolve commit SHAs from branch refs, with tag fallback and annotated tag dereferencing.
- Download GitHub tarballs to temporary storage with max-size protection and cleanup.
- Add focused tests using a local HTTP server instead of the real GitHub API.
- Add a project README covering setup, validation, scripts, architecture, conventions, and PR workflow.

## Validation
- mvn -B -ntp test
- mvn -B -ntp verify