### PR TITLE
Docs: clear README + one-command local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# PortLoko Core API — example environment configuration.
+#
+# Copy this file to `.env` and adjust if needed. EVERY variable here already has
+# a sane local default in core-api/src/main/resources/application.properties,
+# so you only need a real .env when you want to override something.
+#
+# NOTE: tests do NOT need any of this (they use in-memory H2).
+
+# --- Database (matches docker-compose.yml) ---
+DATABASE_URL=jdbc:postgresql://localhost:5432/portloko
+DB_USER=portloko
+DB_PASSWORD=portloko
+
+# --- JWT ---
+# Public key used to verify tokens. The install_start script generates a dev
+# key pair into core-api/src/main/resources/keys/ if it is missing.
+JWT_PUBLIC_KEY_LOCATION=keys/public.pem
+JWT_ISSUER=https://portloko.dev
+
+# --- CORS (frontend origin allowed to call the API) ---
+CORS_ORIGINS=http://localhost:3000
+
+# --- GitHub OAuth app (only needed for the GitHub integration features) ---
+GITHUB_CLIENT_ID=dev-github-client-id
+GITHUB_CLIENT_SECRET=dev-github-client-secret
+GITHUB_API_BASE_URL=https://api.github.com
+GITHUB_ARCHIVE_TEMP_DIR=
+GITHUB_ARCHIVE_MAX_BYTES=52428800
+
+# --- Claude API (only needed for the AI features, BACK-19/20) ---
+CLAUDE_API_KEY=dev-claude-api-key
+
+# --- Runner service (not implemented yet, BACK-3) ---
+RUNNER_URL=http://localhost:8090

--- a/README.md
+++ b/README.md
@@ -1,185 +1,272 @@
 # PortLoko
 
-PortLoko is a developer portfolio platform focused on live, deployable projects. The current repository contains the Quarkus Core API and the CI workflow used to validate it.
+PortLoko is a developer portfolio platform focused on live, deployable projects:
+every project can be deployed and shown as a working demo, not just a repo link.
 
-## Current Stack
+This repository currently contains the **Core API** (Quarkus / Java 21) and its
+CI workflow. The Runner service, the AI module and the frontend are tracked in
+the project's issues and will land incrementally.
 
-- Java 21
-- Quarkus 3.x
-- Maven
-- Hibernate ORM with Panache
-- PostgreSQL in local/dev environments
-- H2 for tests
-- Flyway migrations
-- SmallRye JWT
-- GitHub Actions
+---
 
-## Repository Layout
-
-```text
-Portfolio/
-├── core-api/                 # Quarkus Core API
-│   ├── src/main/java/com/portloko/
-│   │   ├── github/           # GitHub API client
-│   │   ├── project/          # Project model/repository
-│   │   ├── shared/           # Shared exceptions and error mappers
-│   │   └── user/             # User profile API
-│   └── src/main/resources/
-│       ├── application.properties
-│       └── db/migration/     # Flyway migrations
-├── .github/workflows/        # CI workflows
-├── install_start.ps1         # Windows setup/test/build/start helper
-└── install_start.sh          # Unix/Git Bash setup/test/build/start helper
-```
-
-Planned services include a runner service for isolated project builds and deployment orchestration.
-
-## Prerequisites
-
-- Java 21 available in `PATH`
-- Maven available in `PATH`
-- Git
-- GitHub CLI (`gh`) for PR/check commands
-- PostgreSQL for running the API locally against a real database
-
-The tests do not require PostgreSQL because the test profile uses H2.
-
-## Configuration
-
-The Core API reads configuration from environment variables with local defaults in `core-api/src/main/resources/application.properties`.
-
-Useful variables:
-
-```text
-DATABASE_URL=jdbc:postgresql://localhost:5432/portloko
-DB_USER=portloko
-DB_PASSWORD=portloko
-JWT_PUBLIC_KEY_LOCATION=keys/public.pem
-JWT_ISSUER=https://portloko.dev
-CORS_ORIGINS=http://localhost:3000
-GITHUB_API_BASE_URL=https://api.github.com
-GITHUB_ARCHIVE_TEMP_DIR=
-GITHUB_ARCHIVE_MAX_BYTES=52428800
-```
-
-For tests, no local `.env` is required.
-
-## Validate The Project
-
-From the repository root:
-
-```powershell
-cd core-api
-mvn -B -ntp test
-mvn -B -ntp verify
-```
-
-`mvn verify` matches the GitHub Actions validation workflow.
-
-On Windows, you can also use:
-
-```powershell
-.\install_start.ps1 -NoStart
-```
-
-On Git Bash, WSL, Linux, or macOS:
+## TL;DR
 
 ```bash
-NO_START=true ./install_start.sh
-```
+# 1. Just run the tests (no database needed — uses in-memory H2)
+cd core-api && mvn clean verify
 
-The `NoStart` / `NO_START=true` mode runs tests and builds the application without starting Quarkus dev mode.
-
-## Start The Core API
-
-Make sure PostgreSQL is available, then run one of:
-
-```powershell
+# 2. Or do everything in one command (tests + build + Postgres + start the API)
+#    macOS / Linux / Git Bash:
+./install_start.sh
+#    Windows PowerShell:
 .\install_start.ps1
 ```
 
+If `mvn clean verify` ends with `BUILD SUCCESS`, your environment is correct.
+
+---
+
+## Contents
+
+1. [Stack](#stack)
+2. [Prerequisites](#prerequisites)
+3. [Two ways to work](#two-ways-to-work)
+4. [Option A — Validate only (contributors)](#option-a--validate-only-contributors)
+5. [Option B — Run the API for real](#option-b--run-the-api-for-real)
+6. [Configuration](#configuration)
+7. [Project layout](#project-layout)
+8. [API endpoints](#api-endpoints)
+9. [Contributing (branch + PR workflow)](#contributing-branch--pr-workflow)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## Stack
+
+| Layer | Tech |
+|------|------|
+| Language | Java 21 |
+| Framework | Quarkus 3.9 |
+| Build | Maven |
+| ORM | Hibernate ORM with Panache |
+| Database | PostgreSQL (local/dev) · H2 (tests only) |
+| Migrations | Flyway |
+| Auth | SmallRye JWT |
+| CI | GitHub Actions |
+
+---
+
+## Prerequisites
+
+**To run the tests** (the most common case), you only need:
+
+- **Java 21** (`java -version` should print 21)
+- **Maven** (`mvn -v`)
+
+**To start the API for real**, you additionally need:
+
+- **Docker** (to run PostgreSQL via `docker compose`)
+- **openssl** (to generate a local JWT key pair — the start script does it for you)
+
+> Using Java 23+? It works, but Mockito needs an extra flag. The `install_start`
+> scripts add it automatically. If you run Maven by hand, append
+> `-Dnet.bytebuddy.experimental=true`. The recommended setup is **Java 21**.
+
+---
+
+## Two ways to work
+
+PortLoko has two distinct modes, and most contributors only ever need the first:
+
+- **Option A — Validate only.** Compile, run tests, build the jar. **No database, no Docker, no keys.** This is all you need to work on most tickets and to make CI pass.
+- **Option B — Run the API for real.** Actually start the HTTP server and call endpoints. This needs PostgreSQL and a JWT key.
+
+---
+
+## Option A — Validate only (contributors)
+
+This is what the CI runs and what you need for almost every ticket.
+
 ```bash
-./install_start.sh
+cd core-api
+mvn clean verify
 ```
 
-Or start Quarkus directly:
+That compiles the code and runs **all tests** against an in-memory H2 database.
+No PostgreSQL, no Docker, no `.env`, no keys required. Finish on `BUILD SUCCESS`
+and you're good to open a PR.
 
-```powershell
+Shortcut that also checks tooling and builds the jar without starting the server:
+
+```bash
+# macOS / Linux / Git Bash
+NO_START=true ./install_start.sh
+
+# Windows PowerShell
+.\install_start.ps1 -NoStart
+```
+
+---
+
+## Option B — Run the API for real
+
+Use this when you want to actually hit the endpoints (Swagger, curl, frontend).
+
+### One command (recommended)
+
+```bash
+# macOS / Linux / Git Bash
+./install_start.sh
+
+# Windows PowerShell
+.\install_start.ps1
+```
+
+The script will, in order:
+
+1. Check Java + Maven.
+2. Generate a development JWT key pair into `core-api/src/main/resources/keys/` **if it's missing** (these keys are gitignored — each dev has their own).
+3. Run the tests and build the jar.
+4. Start **PostgreSQL** with `docker compose up -d` and wait until it's ready.
+5. Start the API in dev mode (hot reload).
+
+The API then runs at **http://localhost:8080**, with Swagger UI at
+**http://localhost:8080/q/swagger-ui** and health at
+**http://localhost:8080/q/health**.
+
+Stop the API with `Ctrl+C`. Stop the database with `docker compose down`
+(add `-v` to also delete its data).
+
+### Manual steps (if you prefer not to use the script)
+
+```bash
+# 1. Start PostgreSQL
+docker compose up -d
+
+# 2. Generate a dev JWT key pair (once)
+mkdir -p core-api/src/main/resources/keys
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+  -out core-api/src/main/resources/keys/private.pem
+openssl rsa -pubout \
+  -in core-api/src/main/resources/keys/private.pem \
+  -out core-api/src/main/resources/keys/public.pem
+
+# 3. Start the API
 cd core-api
 mvn quarkus:dev
 ```
 
-The API runs on:
+---
+
+## Configuration
+
+All settings have working local defaults in
+`core-api/src/main/resources/application.properties`, so you usually don't need
+to set anything. To override, copy `.env.example` to `.env` and edit it.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DATABASE_URL` | `jdbc:postgresql://localhost:5432/portloko` | Postgres JDBC URL |
+| `DB_USER` / `DB_PASSWORD` | `portloko` / `portloko` | DB credentials (match `docker-compose.yml`) |
+| `JWT_PUBLIC_KEY_LOCATION` | `keys/public.pem` | Public key used to verify JWTs |
+| `JWT_ISSUER` | `https://portloko.dev` | Expected token issuer |
+| `CORS_ORIGINS` | `http://localhost:3000` | Allowed frontend origin |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | dev placeholders | GitHub OAuth app |
+| `CLAUDE_API_KEY` | dev placeholder | AI features (BACK-19/20) |
+| `RUNNER_URL` | `http://localhost:8090` | Runner service (not built yet) |
+
+> Tests need **none** of these — the test profile uses H2 and an embedded key.
+
+---
+
+## Project layout
 
 ```text
-http://localhost:8080
+Portfolio/
+├── docker-compose.yml          # Local PostgreSQL (dev only)
+├── .env.example                # Copy to .env to override defaults
+├── install_start.sh / .ps1     # Setup → test → build → (start) helper
+├── README.md
+├── .github/workflows/          # CI (Core API validation)
+└── core-api/                   # Quarkus Core API
+    ├── pom.xml
+    └── src/
+        ├── main/java/com/portloko/
+        │   ├── auth/           # JWT identity (CurrentUser) + logout
+        │   ├── user/           # User profile API
+        │   ├── project/        # Project model/repository
+        │   ├── github/         # GitHub API client (repos, SHA, archive)
+        │   ├── shared/         # Config, error mappers, shared exceptions
+        │   ├── ai/             # (planned) AI features
+        │   ├── deployment/     # (planned) deployment orchestration
+        │   └── feed/           # (planned) chronological feed
+        └── main/resources/
+            ├── application.properties
+            ├── db/migration/   # Flyway migrations (V1, V2, V3…)
+            └── keys/           # Dev JWT keys (gitignored, auto-generated)
 ```
 
-Swagger UI is included by Quarkus when the application starts.
+---
 
-## GitHub Integration
+## API endpoints
 
-The `com.portloko.github` package contains the GitHub API client used by deployment flows.
+Currently implemented:
 
-Implemented capabilities:
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/me` | JWT | Current user's full profile |
+| PATCH | `/v1/me/profile` | JWT | Update bio / handle / avatar |
+| GET | `/v1/users/{handle}` | public | Public profile + public projects |
+| POST | `/v1/auth/logout` | JWT | Clear the JWT cookie |
+| GET | `/q/health` | public | Liveness/readiness |
+| GET | `/q/swagger-ui` | public | Interactive API docs |
 
-- List authenticated user repositories through `GET /user/repos`
-- Filter repositories by `permissions.push`
-- Paginate GitHub results with `per_page=100`
-- Resolve a branch or tag to a full 40-character commit SHA
-- Download a repository tarball for a specific commit SHA
-- Store archives in a temporary directory
-- Clean up downloaded archives after use
-- Reject archives larger than `GITHUB_ARCHIVE_MAX_BYTES`
+The `com.portloko.github` package also provides a GitHub client (list repos,
+resolve a branch/tag to a commit SHA, download a repo archive) used by upcoming
+deployment flows.
 
-External GitHub calls are covered by unit tests using a local HTTP server, not the real GitHub API.
+---
 
-## Code Conventions
+## Contributing (branch + PR workflow)
 
-- Packages live under `com.portloko.{module}`
-- REST resources end with `Resource`
-- Services end with `Service`
-- Repositories use Panache repositories
-- DTOs are Java records
-- Error responses use `{ "error": "...", "code": "..." }`
-- Tests live in the same package under `src/test/java`
-- Use `@QuarkusTest` for API/integration tests and JUnit + Mockito or local fakes for unit tests
-- Do not commit secrets or local `.env` files
+Never commit to `main`. One branch + one PR per ticket.
 
-## Pull Request Workflow
+```bash
+# 1. Branch from up-to-date main
+git switch main && git pull
+git switch -c feature/BACK-123-short-description
 
-1. Create a feature branch:
+# 2. Make your change with focused tests, then validate
+cd core-api && mvn clean verify
 
-   ```bash
-   git switch -c feature/BACK-123-short-description
-   ```
-
-2. Implement the change with focused tests.
-
-3. Validate locally:
-
-   ```bash
-   cd core-api
-   mvn -B -ntp verify
-   ```
-
-4. Push and open a PR:
-
-   ```bash
-   git push -u origin feature/BACK-123-short-description
-   gh pr create --base main --head feature/BACK-123-short-description
-   ```
-
-5. Wait for the GitHub Actions check `Validate Quarkus Core API` to pass before merging.
-
-## Useful Commands
-
-```powershell
-git status --short
-gh pr checks <pr-number> --repo potichacha/Portfolio
-gh pr view <pr-number> --repo potichacha/Portfolio
+# 3. Push and open a PR
+git push -u origin feature/BACK-123-short-description
+gh pr create --base main --head feature/BACK-123-short-description
 ```
 
-## Notes
+In the PR description, write `Closes #<issue-number>` so the issue closes
+automatically on merge. Wait for the **Validate Quarkus Core API** check to be
+green before merging.
 
-The local scripts use the installed `mvn` command. If the Maven wrapper jar is missing or invalid locally, use `mvn` directly.
+**Conventions:**
+
+- Packages under `com.portloko.{module}`.
+- REST resources end with `Resource`, services with `Service`.
+- Repositories use Panache — **never** build SQL by string concatenation.
+- DTOs are Java `record`s.
+- Error responses use `{ "error": "...", "code": "..." }`.
+- Tests live in the same package under `src/test/java`.
+- Never commit secrets, `.env`, or the `keys/` directory.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| `mvn` not found | Install Maven and put it on your `PATH`. |
+| Tests fail with `Mockito cannot mock ...` | You're on Java 23+. Use Java 21, or add `-Dnet.bytebuddy.experimental=true` (the start scripts do this automatically). |
+| API won't start: connection refused on 5432 | PostgreSQL isn't running. `docker compose up -d`, or use `./install_start.sh`. |
+| API won't start: missing JWT public key | `keys/public.pem` is absent. Re-run `./install_start.sh`, or generate it manually (see Option B). |
+| Port 8080 already in use | Stop the other process, or set `quarkus.http.port`. |
+| Want to wipe the DB | `docker compose down -v` then `docker compose up -d`. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# PortLoko — local development services.
+#
+# For now this only provides PostgreSQL, which the Core API needs to run
+# (tests use in-memory H2 and do NOT need this). The full stack (Traefik,
+# Runner, isolated project network) arrives with BACK-2/3/4.
+#
+# Start it with:  docker compose up -d
+# Stop it with:   docker compose down       (add -v to also wipe the data)
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: portloko-postgres
+    environment:
+      POSTGRES_USER: portloko
+      POSTGRES_PASSWORD: portloko
+      POSTGRES_DB: portloko
+    ports:
+      - "5432:5432"
+    volumes:
+      - portloko_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U portloko -d portloko"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  portloko_pgdata:

--- a/install_start.ps1
+++ b/install_start.ps1
@@ -9,6 +9,7 @@ if (Test-Path Variable:\PSNativeCommandUseErrorActionPreference) {
 
 $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $CoreApiDir = Join-Path $RootDir "core-api"
+$KeysDir = Join-Path $CoreApiDir "src/main/resources/keys"
 
 function Section($Message) {
     Write-Host ""
@@ -40,6 +41,7 @@ Require-Command mvn
 $javaVersionOutput = & java -version 2>&1
 Write-Host ($javaVersionOutput -join "`n")
 
+# Java 23+ needs Byte Buddy experimental mode for the test mocks to load.
 $mavenArgs = @()
 if (($javaVersionOutput -join "`n") -match 'version "([0-9]+)') {
     $major = [int]$Matches[1]
@@ -49,7 +51,23 @@ if (($javaVersionOutput -join "`n") -match 'version "([0-9]+)') {
     }
 }
 
-Section "Running tests"
+# Generate a development JWT key pair if it is missing. These keys are
+# gitignored: every developer has their own local pair.
+$publicKey = Join-Path $KeysDir "public.pem"
+if (-not (Test-Path $publicKey)) {
+    Section "Generating development JWT key pair (keys/ is gitignored)"
+    if (Get-Command openssl -ErrorAction SilentlyContinue) {
+        New-Item -ItemType Directory -Force -Path $KeysDir | Out-Null
+        $privateKey = Join-Path $KeysDir "private.pem"
+        & openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $privateKey 2>$null
+        & openssl rsa -pubout -in $privateKey -out $publicKey 2>$null
+        Write-Host "Created $KeysDir\{private,public}.pem"
+    } else {
+        Write-Host "WARNING: openssl not found - cannot create JWT keys. Generate them manually." -ForegroundColor Yellow
+    }
+}
+
+Section "Running tests (in-memory H2, no database needed)"
 Invoke-Maven ($mavenArgs + @("clean", "test"))
 
 Section "Building application"
@@ -61,7 +79,30 @@ if ($NoStart) {
     exit 0
 }
 
+# Starting the API for real needs PostgreSQL. Bring it up via docker compose
+# when Docker is available; otherwise tell the developer what to do.
+Section "Starting PostgreSQL (docker compose)"
+if (Get-Command docker -ErrorAction SilentlyContinue) {
+    Push-Location $RootDir
+    try {
+        & docker compose up -d
+        Write-Host "Waiting for PostgreSQL to be ready..."
+        for ($i = 0; $i -lt 30; $i++) {
+            & docker compose exec -T postgres pg_isready -U portloko -d portloko *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "PostgreSQL is ready."
+                break
+            }
+            Start-Sleep -Seconds 1
+        }
+    } finally {
+        Pop-Location
+    }
+} else {
+    Write-Host "WARNING: Docker not found. Start PostgreSQL yourself or set DATABASE_URL, then re-run." -ForegroundColor Yellow
+}
+
 Section "Starting Core API"
-Write-Host "If PostgreSQL is not available, start it or set DATABASE_URL before running this script." -ForegroundColor Yellow
-Write-Host "Core API will run on http://localhost:8080. Press Ctrl+C to stop."
+Write-Host "Core API will run on http://localhost:8080 (Swagger UI at /q/swagger-ui)."
+Write-Host "Press Ctrl+C to stop. To stop PostgreSQL afterwards: docker compose down"
 Invoke-Maven ($mavenArgs + @("quarkus:dev"))

--- a/install_start.sh
+++ b/install_start.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CORE_API_DIR="$ROOT_DIR/core-api"
+KEYS_DIR="$CORE_API_DIR/src/main/resources/keys"
 NO_START="${NO_START:-false}"
 
 info() {
@@ -21,6 +22,7 @@ require_cmd java
 require_cmd mvn
 java -version
 
+# Java 23+ needs Byte Buddy experimental mode for the test mocks to load.
 MAVEN_ARGS=()
 JAVA_VERSION_OUTPUT="$(java -version 2>&1 || true)"
 if [[ "$JAVA_VERSION_OUTPUT" =~ version\ \"([0-9]+) ]]; then
@@ -30,9 +32,25 @@ if [[ "$JAVA_VERSION_OUTPUT" =~ version\ \"([0-9]+) ]]; then
   fi
 fi
 
+# Generate a development JWT key pair if it is missing. These keys are
+# gitignored: every developer has their own local pair.
+if [[ ! -f "$KEYS_DIR/public.pem" ]]; then
+  info "Generating development JWT key pair (keys/ is gitignored)"
+  if command -v openssl >/dev/null 2>&1; then
+    mkdir -p "$KEYS_DIR"
+    openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$KEYS_DIR/private.pem" 2>/dev/null
+    openssl rsa -pubout -in "$KEYS_DIR/private.pem" -out "$KEYS_DIR/public.pem" 2>/dev/null
+    echo "Created $KEYS_DIR/{private,public}.pem"
+  else
+    echo "WARNING: openssl not found — cannot create JWT keys. Generate them manually:"
+    echo "  openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $KEYS_DIR/private.pem"
+    echo "  openssl rsa -pubout -in $KEYS_DIR/private.pem -out $KEYS_DIR/public.pem"
+  fi
+fi
+
 cd "$CORE_API_DIR"
 
-info "Running tests"
+info "Running tests (in-memory H2, no database needed)"
 mvn "${MAVEN_ARGS[@]}" clean test
 
 info "Building application"
@@ -44,7 +62,25 @@ if [[ "$NO_START" == "true" ]]; then
   exit 0
 fi
 
+# Starting the API for real needs PostgreSQL. Bring it up via docker compose
+# when Docker is available; otherwise tell the developer what to do.
+info "Starting PostgreSQL (docker compose)"
+if command -v docker >/dev/null 2>&1; then
+  (cd "$ROOT_DIR" && docker compose up -d)
+  echo "Waiting for PostgreSQL to be ready..."
+  for _ in $(seq 1 30); do
+    if (cd "$ROOT_DIR" && docker compose exec -T postgres pg_isready -U portloko -d portloko >/dev/null 2>&1); then
+      echo "PostgreSQL is ready."
+      break
+    fi
+    sleep 1
+  done
+else
+  echo "WARNING: Docker not found. Start PostgreSQL yourself or set DATABASE_URL,"
+  echo "then re-run. The API will fail to start without a reachable database."
+fi
+
 info "Starting Core API"
-echo "If PostgreSQL is not available, start it or set DATABASE_URL before running this script."
-echo "Core API will run on http://localhost:8080. Press Ctrl+C to stop."
+echo "Core API will run on http://localhost:8080 (Swagger UI at /q/swagger-ui)."
+echo "Press Ctrl+C to stop. To stop PostgreSQL afterwards: docker compose down"
 mvn "${MAVEN_ARGS[@]}" quarkus:dev


### PR DESCRIPTION
Rewrites the README and adds docker-compose + .env.example + JWT key auto-generation in install_start. Validated: mvn verify (35 tests) and real startup (health UP, Flyway migrations applied).